### PR TITLE
Shape errors with some STL lines

### DIFF
--- a/app/Jobs/RealtimeData/NextbusJsonHandler.php
+++ b/app/Jobs/RealtimeData/NextbusJsonHandler.php
@@ -142,7 +142,7 @@ class NextbusJsonHandler implements ShouldQueue
         if ($this->agency->slug === 'stl') {
             return Route::where([
                 ['agency_id', $this->agency->id],
-                ['gtfs_route_id', 'LIKE', "%{$routeTag}"],
+                ['gtfs_route_id', 'LIKE', "______{$routeTag}"],
                 ['short_name', substr($routeTag, 0, -1)],
             ])
                 ->select('gtfs_route_id')


### PR DESCRIPTION
There are some conflicts currently for example line 45 displays the shape of line 345.
It seems like the prefix used by the STL is always 6 characters (ex. AOUT24).