### PR TITLE
feat: add STLGTFSManipulation agency feature flag

### DIFF
--- a/app/Enums/AgencyFeature.php
+++ b/app/Enums/AgencyFeature.php
@@ -14,4 +14,6 @@ final class AgencyFeature extends Enum
     const PredictedBlocks = 'predictedBlocks';
 
     const UseRouteFromTrip = 'useRouteFromTrip';
+
+    const STLGTFSManipulation = 'STLGTFSManipulation';
 }

--- a/app/Jobs/StaticData/ProcessGtfsRoutes.php
+++ b/app/Jobs/StaticData/ProcessGtfsRoutes.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use App\Enums\AgencyFeature;
 use League\Csv\Reader;
 
 class ProcessGtfsRoutes implements ShouldQueue
@@ -30,14 +31,21 @@ class ProcessGtfsRoutes implements ShouldQueue
 
         $routesToUpdate = [];
 
+        $hasSTLGTFSManipulation = $this->agency->features?->contains(AgencyFeature::STLGTFSManipulation);
+
         foreach ($routesReader->getRecords() as $route) {
             if (! array_key_exists('route_id', $route)) {
                 continue;
             }
 
+            $routeId = $route['route_id'];
+            if ($hasSTLGTFSManipulation && strlen($routeId) > 6) {
+                $routeId = substr($routeId, 6);
+            }
+
             $routesToUpdate[] = [
                 'agency_id' => $this->agency->id,
-                'gtfs_route_id' => $route['route_id'],
+                'gtfs_route_id' => $routeId,
                 'type' => VehicleType::coerce($route['route_type'])?->value ?? 3, // Assume bus if none (required field per spec - bus most common)
                 'short_name' => $route['route_short_name'],
                 'long_name' => $route['route_long_name'],

--- a/app/Jobs/StaticData/ProcessGtfsStopTimes.php
+++ b/app/Jobs/StaticData/ProcessGtfsStopTimes.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use App\Enums\AgencyFeature;
 use League\Csv\Reader;
 use League\Csv\Statement;
 
@@ -35,13 +36,20 @@ class ProcessGtfsStopTimes implements ShouldQueue
 
         $toCreate = [];
 
+        $hasSTLGTFSManipulation = $this->agency->features?->contains(AgencyFeature::STLGTFSManipulation);
+
         foreach ($statement->process($reader) as $record) {
             // If there is no trip_id or arrival_time, skip
             if (! Arr::exists($record, 'trip_id') || ! Arr::exists($record, 'arrival_time')) {
                 continue;
             }
 
-            $shouldNotImportThisTrip = $tripIdToImport->doesntContain($record['trip_id']);
+            $tripId = $record['trip_id'];
+            if ($hasSTLGTFSManipulation && strlen($tripId) > 6) {
+                $tripId = substr($tripId, 6);
+            }
+
+            $shouldNotImportThisTrip = $tripIdToImport->doesntContain($tripId);
 
             // For agencies that do not support blocks, only import StopTimes for one trip per shape
             // of for agencies that do support blocks, import first StopTimes for all trip (normally 1, or 0 for some special agencies...)
@@ -54,7 +62,7 @@ class ProcessGtfsStopTimes implements ShouldQueue
 
             $toCreate[] = [
                 'agency_id' => $this->agency->id,
-                'gtfs_trip_id' => $record['trip_id'],
+                'gtfs_trip_id' => $tripId,
                 'gtfs_stop_id' => $record['stop_id'],
                 'departure' => $record['departure_time'],
                 'sequence' => (int) $record['stop_sequence'],

--- a/app/Jobs/StaticData/ProcessGtfsTrips.php
+++ b/app/Jobs/StaticData/ProcessGtfsTrips.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
+use App\Enums\AgencyFeature;
 use League\Csv\Reader;
 use League\Csv\Statement;
 
@@ -30,11 +31,25 @@ class ProcessGtfsTrips implements ShouldQueue
 
         $tripsToUpdate = [];
 
+        $hasSTLGTFSManipulation = $this->agency->features?->contains(AgencyFeature::STLGTFSManipulation);
+
         foreach ($tripsRecords as $trip) {
+            $tripId = $trip['trip_id'];
+            $routeId = $trip['route_id'];
+
+            if ($hasSTLGTFSManipulation) {
+                if (strlen($tripId) > 6) {
+                    $tripId = substr($tripId, 6);
+                }
+                if (strlen($routeId) > 6) {
+                    $routeId = substr($routeId, 6);
+                }
+            }
+
             $tripsToUpdate[] = [
                 'agency_id' => $this->agency->id,
-                'gtfs_trip_id' => $trip['trip_id'],
-                'gtfs_route_id' => $trip['route_id'],
+                'gtfs_trip_id' => $tripId,
+                'gtfs_route_id' => $routeId,
                 'gtfs_service_id' => $trip['service_id'],
                 'gtfs_block_id' => $this->getField($trip, 'block_id'),
                 'gtfs_shape_id' => $this->getField($trip, 'shape_id'),


### PR DESCRIPTION
Adds a new agency feature flag, `STLGTFSManipulation`, which intercepts the static GTFS import pipeline. When present, the logic will remove the first six characters of `route_id` and `trip_id` values parsed from the source static GTFS data (applies to `routes.txt`, `trips.txt`, and `stop_times.txt`). Values that are already 6 characters or shorter are left alone as a safety measure.

---
*PR created automatically by Jules for task [5377952946801825009](https://jules.google.com/task/5377952946801825009) started by @FelixINX*